### PR TITLE
chore: rename config-repo -> dotfiles throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# config-repo
+# dotfiles
 
 [reference: setup](https://qiita.com/taiyo2001/items/2a5869f4f3b8b7aba081)
 
@@ -8,7 +8,6 @@
 |---|---|
 | `dot_*` | chezmoi 管理の dotfiles |
 | `app/` | アプリケーション別セットアップ手順 |
-| `dotfiles/` | レガシー設定ファイル（zsh等） |
 
 ## セットアップ（新規マシン）
 
@@ -33,11 +32,12 @@ eval $(op signin)
 > |---|---|---|
 > | Personal | `Git Config` | `email` |
 > | Personal | `Git Config` | `signingkey` |
+> | Personal | `Claude Code` | `org_uuid` |
 
 ### 3. chezmoiでセットアップ（クローン＋適用を一括）
 
 ```sh
-chezmoi init --apply taiyo2001/config-repo
+chezmoi init --apply taiyo2001
 ```
 
 リポジトリは `~/.local/share/chezmoi/` に自動でクローンされます。

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,5 @@
 services:
   zsh-alias:
     build: .
-    container_name: config-repo-container
+    container_name: dotfiles-container
     tty: true

--- a/utils/colors.sh
+++ b/utils/colors.sh
@@ -2,7 +2,7 @@
 
 # ===============================================
 # exec source colors.sh script
-# FILE_PATH="$HOME/config-repo/utils/colors.sh"
+# FILE_PATH="$HOME/.local/share/chezmoi/utils/colors.sh"
 # source $FILE_PATH
 # ===============================================
 


### PR DESCRIPTION
## Summary

GitHub でリポジトリ名を `config-repo` → `dotfiles` に変更したことに伴う修正。

| ファイル | 変更内容 |
|---|---|
| `README.md` | タイトル・`chezmoi init` コマンド（`taiyo2001` のみで OK に）・削除済みの `dotfiles/` 行を削除・`Claude Code` 1Password アイテムを追記 |
| `compose.yml` | `container_name: config-repo-container` → `dotfiles-container` |
| `utils/colors.sh` | コメント内のパスを更新 |

## Test plan

- [ ] CI Green 確認
- [ ] `chezmoi init --apply taiyo2001` で新規セットアップが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)