### PR TITLE
feat: tpm・tmux プラグインのインストールを自動化

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ macOS 向け dotfiles。[chezmoi](https://www.chezmoi.io/) + [1Password CLI](htt
   <tbody>
     <tr><td>環境管理</td><td><a href="https://www.chezmoi.io/">chezmoi</a> · <a href="https://brew.sh/">Homebrew</a> · <a href="https://mise.jdx.dev/">mise</a> · <a href="https://developer.1password.com/docs/cli/">1Password CLI</a></td></tr>
     <tr><td>シェル</td><td>zsh + <a href="https://sheldon.cli.rs/">Sheldon</a> · <a href="https://starship.rs/">Starship</a> · <a href="https://atuin.sh/">atuin</a> · <a href="https://github.com/ajeetdsouza/zoxide">zoxide</a> · <a href="https://github.com/sharkdp/fd">fd</a> + <a href="https://github.com/junegunn/fzf">fzf</a></td></tr>
-    <tr><td>開発環境</td><td><a href="https://neovim.io/">Neovim</a> · <a href="https://github.com/tmux/tmux">tmux</a> · <a href="https://www.cmux.dev/">cmux</a></td></tr>
+    <tr><td>開発環境</td><td><a href="https://neovim.io/">Neovim</a> · <a href="https://github.com/tmux/tmux">tmux</a> + <a href="https://github.com/tmux-plugins/tpm">tpm</a> · <a href="https://www.cmux.dev/">cmux</a></td></tr>
     <tr><td>Git</td><td><a href="https://github.com/evilmartians/lefthook">lefthook</a></td></tr>
   </tbody>
 </table>
+
+> **Note:** tmux のプレフィックスキーはデフォルトの `Ctrl+b` から `Ctrl+q` に変更しています。
 
 ## 構成
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ make -C ~/.local/share/chezmoi setup/apply
 - Homebrew パッケージ（Brewfile）のインストール
 - macOS システム設定の変更
 - `lefthook install` による Git フックのセットアップ
+- tpm（Tmux Plugin Manager）および tmux プラグインのインストール
 
 ### アプリケーションごとのセットアップ
 

--- a/app/README.md
+++ b/app/README.md
@@ -11,11 +11,3 @@
 > **Note:** 現在はメインターミナルとして [cmux](https://www.cmux.dev/) を使用。iTerm2 設定は参考として保持。
 
 [reference: BetterTouchTool](https://webrandum.net/bettertouchtool-export-import/)
-
-### tpm (Tmux Plugin Manager)
-
-`chezmoi apply` 実行時に `run_once_install-tpm.sh` が自動でインストールします。手動操作は不要です。
-
-> **Note:** tmux のプレフィックスキーはデフォルトの `Ctrl+b` から `Ctrl+q` に変更しています。
-
-参考：[document](https://github.com/tmux-plugins/tpm)

--- a/app/README.md
+++ b/app/README.md
@@ -13,15 +13,9 @@
 [reference: BetterTouchTool](https://webrandum.net/bettertouchtool-export-import/)
 
 ### tpm (Tmux Plugin Manager)
-tpmを導入
-```
-git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
-```
 
-tpm管理のプラグインをインストール
+`chezmoi apply` 実行時に `run_once_install-tpm.sh` が自動でインストールします。手動操作は不要です。
 
-tmux内で以下を実行
-```
-pfx + I
-```
+> **Note:** tmux のプレフィックスキーはデフォルトの `Ctrl+b` から `Ctrl+q` に変更しています。
+
 参考：[document](https://github.com/tmux-plugins/tpm)

--- a/home/run_once_install-tpm.sh
+++ b/home/run_once_install-tpm.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+TPM_DIR="$HOME/.tmux/plugins/tpm"
+
+if [[ ! -d "$TPM_DIR" ]]; then
+  echo "tpm をインストールしています..."
+  git clone https://github.com/tmux-plugins/tpm "$TPM_DIR"
+fi
+
+echo "tpm プラグインをインストールしています..."
+"$TPM_DIR/bin/install_plugins"
+echo "tpm プラグインのインストールが完了しました。"


### PR DESCRIPTION
## Summary

- `run_once_install-tpm.sh` を追加し、`chezmoi apply` 時に tpm のクローンと tmux プラグインのインストールを自動実行
- `app/README.md` の tpm セクションを手動手順から自動化の説明に更新し、プレフィックスキーが `Ctrl+q` である旨を追記
- `README.md` のセットアップ手順に tpm 自動インストールを追記

## Test plan

- [ ] 新マシンで `chezmoi apply` 後に `~/.tmux/plugins/tpm` が存在することを確認
- [ ] `~/.tmux/plugins/tmux-prefix-highlight` など設定済みプラグインがインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)