### PR TITLE
feat: AeroSpace を chezmoi に統合

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ macOS 向け dotfiles。[chezmoi](https://www.chezmoi.io/) + [1Password CLI](htt
     <tr><td>環境管理</td><td><a href="https://www.chezmoi.io/">chezmoi</a> · <a href="https://brew.sh/">Homebrew</a> · <a href="https://mise.jdx.dev/">mise</a> · <a href="https://developer.1password.com/docs/cli/">1Password CLI</a></td></tr>
     <tr><td>シェル</td><td>zsh + <a href="https://sheldon.cli.rs/">Sheldon</a> · <a href="https://starship.rs/">Starship</a> · <a href="https://atuin.sh/">atuin</a> · <a href="https://github.com/ajeetdsouza/zoxide">zoxide</a> · <a href="https://github.com/sharkdp/fd">fd</a> + <a href="https://github.com/junegunn/fzf">fzf</a></td></tr>
     <tr><td>開発環境</td><td><a href="https://neovim.io/">Neovim</a> · <a href="https://github.com/tmux/tmux">tmux</a> + <a href="https://github.com/tmux-plugins/tpm">tpm</a> · <a href="https://www.cmux.dev/">cmux</a></td></tr>
-    <tr><td>ウィンドウ管理</td><td><a href="https://nikitabobko.github.io/AeroSpace/">AeroSpace</a> + <a href="https://github.com/acsandmann/aerospace-swipe">aerospace-swipe</a> (トラックパッドでワークスペース切替)</td></tr>
+    <tr><td>ウィンドウ管理</td><td><a href="https://nikitabobko.github.io/AeroSpace/">AeroSpace</a> + <a href="https://github.com/taiyo2001/aerospace-swipe">aerospace-swipe</a> (3本指スワイプでワークスペース切替) · <a href="https://www.hammerspoon.org/">Hammerspoon</a></td></tr>
     <tr><td>Git</td><td><a href="https://github.com/evilmartians/lefthook">lefthook</a></td></tr>
     <tr><td>インフラ</td><td><a href="https://www.terraform.io/">Terraform</a> + <a href="https://app.terraform.io/">HCP Terraform</a></td></tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ macOS 向け dotfiles。[chezmoi](https://www.chezmoi.io/) + [1Password CLI](htt
     <tr><td>環境管理</td><td><a href="https://www.chezmoi.io/">chezmoi</a> · <a href="https://brew.sh/">Homebrew</a> · <a href="https://mise.jdx.dev/">mise</a> · <a href="https://developer.1password.com/docs/cli/">1Password CLI</a></td></tr>
     <tr><td>シェル</td><td>zsh + <a href="https://sheldon.cli.rs/">Sheldon</a> · <a href="https://starship.rs/">Starship</a> · <a href="https://atuin.sh/">atuin</a> · <a href="https://github.com/ajeetdsouza/zoxide">zoxide</a> · <a href="https://github.com/sharkdp/fd">fd</a> + <a href="https://github.com/junegunn/fzf">fzf</a></td></tr>
     <tr><td>開発環境</td><td><a href="https://neovim.io/">Neovim</a> · <a href="https://github.com/tmux/tmux">tmux</a> + <a href="https://github.com/tmux-plugins/tpm">tpm</a> · <a href="https://www.cmux.dev/">cmux</a></td></tr>
-    <tr><td>ウィンドウ管理</td><td><a href="https://nikitabobko.github.io/AeroSpace/">AeroSpace</a> + <a href="https://github.com/taiyo2001/aerospace-swipe">aerospace-swipe</a> (3本指スワイプでワークスペース切替) · <a href="https://www.hammerspoon.org/">Hammerspoon</a></td></tr>
+    <tr><td>ウィンドウ管理</td><td><a href="https://nikitabobko.github.io/AeroSpace/">AeroSpace</a> + <a href="https://github.com/taiyo2001/aerospace-swipe">aerospace-swipe</a></td></tr>
     <tr><td>Git</td><td><a href="https://github.com/evilmartians/lefthook">lefthook</a></td></tr>
     <tr><td>インフラ</td><td><a href="https://www.terraform.io/">Terraform</a> + <a href="https://app.terraform.io/">HCP Terraform</a></td></tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ macOS 向け dotfiles。[chezmoi](https://www.chezmoi.io/) + [1Password CLI](htt
     <tr><td>環境管理</td><td><a href="https://www.chezmoi.io/">chezmoi</a> · <a href="https://brew.sh/">Homebrew</a> · <a href="https://mise.jdx.dev/">mise</a> · <a href="https://developer.1password.com/docs/cli/">1Password CLI</a></td></tr>
     <tr><td>シェル</td><td>zsh + <a href="https://sheldon.cli.rs/">Sheldon</a> · <a href="https://starship.rs/">Starship</a> · <a href="https://atuin.sh/">atuin</a> · <a href="https://github.com/ajeetdsouza/zoxide">zoxide</a> · <a href="https://github.com/sharkdp/fd">fd</a> + <a href="https://github.com/junegunn/fzf">fzf</a></td></tr>
     <tr><td>開発環境</td><td><a href="https://neovim.io/">Neovim</a> · <a href="https://github.com/tmux/tmux">tmux</a> + <a href="https://github.com/tmux-plugins/tpm">tpm</a> · <a href="https://www.cmux.dev/">cmux</a></td></tr>
+    <tr><td>ウィンドウ管理</td><td><a href="https://nikitabobko.github.io/AeroSpace/">AeroSpace</a> + <a href="https://github.com/acsandmann/aerospace-swipe">aerospace-swipe</a> (トラックパッドでワークスペース切替)</td></tr>
     <tr><td>Git</td><td><a href="https://github.com/evilmartians/lefthook">lefthook</a></td></tr>
   </tbody>
 </table>

--- a/app/README.md
+++ b/app/README.md
@@ -11,3 +11,10 @@
 > **Note:** 現在はメインターミナルとして [cmux](https://www.cmux.dev/) を使用。iTerm2 設定は参考として保持。
 
 [reference: BetterTouchTool](https://webrandum.net/bettertouchtool-export-import/)
+
+### AeroSpace + aerospace-swipe (3本指スワイプでワークスペース切替)
+
+3本指スワイプによるワークスペース切替は [aerospace-swipe](https://github.com/taiyo2001/aerospace-swipe)（acsandmann/aerospace-swipe のフォーク）で行う。`MultitouchSupport` で生のトラックパッドタッチを読むため Homebrew では入らず、`make install` でビルドして launchd 常駐させる。`make setup/apply` 時に `run_onchange_after_install-aerospace-swipe.sh` が自動でビルド・常駐登録する。
+
+1. ビルドは自動（`ghq get taiyo2001/aerospace-swipe` → `make install`）。フォークを更新したらスクリプト内の `revision` 行を変えると再ビルドされる
+2. 初回のみ System Settings > Privacy & Security > Accessibility で **AerospaceSwipe** を有効化（ad-hoc 署名のため再ビルドのたびに再付与が必要）

--- a/home/dot_Brewfile.tmpl
+++ b/home/dot_Brewfile.tmpl
@@ -1,4 +1,3 @@
-tap "acsandmann/tap"
 tap "coderabbitai/tap"
 tap "manaflow-ai/cmux"
 tap "nikitabobko/tap"
@@ -39,11 +38,11 @@ brew "zoxide"
 brew "zsh-completions"
 brew "coderabbitai/tap/git-gtr"
 cask "1password-cli"
-cask "acsandmann/tap/aerospace-swipe"
 cask "claude-code"
 cask "cmux"
 cask "docker-desktop"
 cask "font-hack-nerd-font"
+cask "hammerspoon"
 cask "karabiner-elements"
 cask "monitorcontrol"
 cask "nikitabobko/tap/aerospace"
@@ -52,7 +51,6 @@ cask "raycast"
 # ── Personal ──────────────────────────────────────────────────────
 {{ if .personal -}}
 cask "bettertouchtool"
-cask "hammerspoon"
 cask "tableplus"
 {{ end -}}
 

--- a/home/dot_Brewfile.tmpl
+++ b/home/dot_Brewfile.tmpl
@@ -1,7 +1,7 @@
+tap "acsandmann/tap"
 tap "coderabbitai/tap"
-tap "homebrew/bundle"
-tap "homebrew/services"
 tap "manaflow-ai/cmux"
+tap "nikitabobko/tap"
 
 # ── Core ──────────────────────────────────────────────────────────
 brew "awscli"
@@ -39,12 +39,14 @@ brew "zoxide"
 brew "zsh-completions"
 brew "coderabbitai/tap/git-gtr"
 cask "1password-cli"
+cask "acsandmann/tap/aerospace-swipe"
 cask "claude-code"
 cask "cmux"
 cask "docker-desktop"
 cask "font-hack-nerd-font"
 cask "karabiner-elements"
 cask "monitorcontrol"
+cask "nikitabobko/tap/aerospace"
 cask "raycast"
 
 # ── Personal ──────────────────────────────────────────────────────

--- a/home/dot_config/aerospace-swipe/config.json
+++ b/home/dot_config/aerospace-swipe/config.json
@@ -1,0 +1,8 @@
+{
+  "natural_swipe": false,
+  "haptic": true,
+  "distance_pct": 0.02,
+  "velocity_pct": 0.05,
+  "settle_factor": 1.0,
+  "swipe_tolerance": 5
+}

--- a/home/dot_config/aerospace/aerospace.toml.tmpl
+++ b/home/dot_config/aerospace/aerospace.toml.tmpl
@@ -36,6 +36,10 @@ default-root-container-orientation = 'auto'
 # Fallback value (if you omit the key): on-focused-monitor-changed = []
 on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 
+# Keep WS F free of tiling: re-float its windows whenever F becomes focused,
+# which also catches windows manually moved into F (on-window-detected misses those).
+exec-on-workspace-change = ['/bin/bash', '{{ .chezmoi.homeDir }}/.config/aerospace/float-f.sh']
+
 # You can effectively turn off macOS "Hide application" (cmd-h) feature by toggling this flag
 # Useful if you don't use this macOS feature, but accidentally hit cmd-h or cmd-alt-h key
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
@@ -193,6 +197,9 @@ on-mode-changed = []
     alt-shift-x = 'move-node-to-workspace X'
     alt-shift-y = 'move-node-to-workspace Y'
     alt-shift-z = 'move-node-to-workspace Z'
+
+    alt-right = 'exec-and-forget {{ .chezmoi.homeDir }}/.config/aerospace/ws-nav.sh next'
+    alt-left  = 'exec-and-forget {{ .chezmoi.homeDir }}/.config/aerospace/ws-nav.sh prev'
 
     # See: https://nikitabobko.github.io/AeroSpace/commands#workspace-back-and-forth
     alt-tab = 'workspace-back-and-forth'

--- a/home/dot_config/aerospace/aerospace.toml.tmpl
+++ b/home/dot_config/aerospace/aerospace.toml.tmpl
@@ -198,6 +198,7 @@ on-mode-changed = []
     alt-shift-y = 'move-node-to-workspace Y'
     alt-shift-z = 'move-node-to-workspace Z'
 
+    # Same-monitor, non-empty workspace navigation
     alt-right = 'exec-and-forget {{ .chezmoi.homeDir }}/.config/aerospace/ws-nav.sh next'
     alt-left  = 'exec-and-forget {{ .chezmoi.homeDir }}/.config/aerospace/ws-nav.sh prev'
 

--- a/home/dot_config/aerospace/executable_float-f.sh
+++ b/home/dot_config/aerospace/executable_float-f.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+# 'on-window-detected if.workspace=F' only fires on window *detection*, not when
+# a window is moved into F from another workspace. Re-floating every window each
+# time F becomes focused covers those manually-moved windows too.
+[[ "${AEROSPACE_FOCUSED_WORKSPACE:-}" == "F" ]] || exit 0
+
+AS=/opt/homebrew/bin/aerospace
+while IFS= read -r wid; do
+  [[ -n "$wid" ]] || continue
+  "$AS" layout floating --window-id "$wid" 2> /dev/null || true
+done < <("$AS" list-windows --workspace F --format '%{window-id}')

--- a/home/dot_config/aerospace/executable_ws-nav.sh
+++ b/home/dot_config/aerospace/executable_ws-nav.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Cycle through non-empty workspaces on the focused monitor.
+# Usage: ws-nav.sh next | prev
+
+set -euo pipefail
+DIR="${1:-next}"
+AS=/opt/homebrew/bin/aerospace
+
+# Anchor on the focused MONITOR and its visible workspace.
+# Reason: 'workspace --focused' returns the workspace of the focused window,
+# which can stay on the previous monitor if you opt+<key> into an empty WS.
+MON_ID=$("$AS" list-monitors --focused --format '%{monitor-id}')
+CUR=$("$AS" list-workspaces --monitor "$MON_ID" --visible --format '%{workspace}')
+
+WS=()
+while IFS= read -r line; do
+  WS+=("$line")
+done < <("$AS" list-workspaces --monitor "$MON_ID" --empty no --format '%{workspace}')
+
+CNT=${#WS[@]}
+[[ $CNT -eq 0 ]] && exit 0
+
+IDX=-1
+for i in "${!WS[@]}"; do
+  if [[ "${WS[$i]}" == "$CUR" ]]; then
+    IDX=$i
+    break
+  fi
+done
+
+if [[ $IDX -eq -1 ]]; then
+  if [[ "$DIR" == "prev" ]]; then TARGET="${WS[$((CNT - 1))]}"; else TARGET="${WS[0]}"; fi
+else
+  if [[ "$DIR" == "prev" ]]; then
+    NEXT=$(((IDX - 1 + CNT) % CNT))
+  else
+    NEXT=$(((IDX + 1) % CNT))
+  fi
+  TARGET="${WS[$NEXT]}"
+fi
+
+"$AS" workspace "$TARGET"
+# Force focus back to our anchor monitor. macOS app activation (e.g., Chrome)
+# can otherwise pull focus to a same-app window on another monitor.
+"$AS" focus-monitor "$MON_ID" 2> /dev/null || true

--- a/home/dot_config/aerospace/executable_ws-nav.sh
+++ b/home/dot_config/aerospace/executable_ws-nav.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Cycle through non-empty workspaces on the focused monitor.
 # Usage: ws-nav.sh next | prev
 
 set -euo pipefail

--- a/home/run_onchange_after_install-aerospace-swipe.sh
+++ b/home/run_onchange_after_install-aerospace-swipe.sh
@@ -7,7 +7,7 @@ if [[ "$(uname)" != "Darwin" ]]; then
   exit 0
 fi
 
-if ! command -v make >/dev/null 2>&1 || ! command -v ghq >/dev/null 2>&1; then
+if ! command -v make > /dev/null 2>&1 || ! command -v ghq > /dev/null 2>&1; then
   echo "make / ghq が無いため aerospace-swipe のインストールをスキップしました。"
   exit 0
 fi
@@ -25,7 +25,7 @@ git -C "$src" checkout --quiet "$rev"
 
 # ad-hoc 署名のため再ビルドのたびに署名が変わり、launchctl load が
 # 二重登録エラーになる。先に unload してから make install で登録し直す
-launchctl unload "$HOME/Library/LaunchAgents/com.acsandmann.swipe.plist" 2>/dev/null || true
+launchctl unload "$HOME/Library/LaunchAgents/com.acsandmann.swipe.plist" 2> /dev/null || true
 (cd "$src" && make install)
 
 echo "aerospace-swipe をインストールしました。"

--- a/home/run_onchange_after_install-aerospace-swipe.sh
+++ b/home/run_onchange_after_install-aerospace-swipe.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Re-runs on `chezmoi apply` whenever this file changes.
+# rev を更新すると再ビルドされる (chezmoi がこのファイルのハッシュ変化で検知)
+set -euo pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  exit 0
+fi
+
+if ! command -v make >/dev/null 2>&1 || ! command -v ghq >/dev/null 2>&1; then
+  echo "make / ghq が無いため aerospace-swipe のインストールをスキップしました。"
+  exit 0
+fi
+
+rev="ca0711a"
+repo="taiyo2001/aerospace-swipe"
+src="$(ghq root)/github.com/${repo}"
+
+if [[ ! -d "$src" ]]; then
+  ghq get "$repo"
+fi
+# レビュー済みリビジョンに固定して再現性を担保する
+git -C "$src" fetch --quiet origin
+git -C "$src" checkout --quiet "$rev"
+
+# ad-hoc 署名のため再ビルドのたびに署名が変わり、launchctl load が
+# 二重登録エラーになる。先に unload してから make install で登録し直す
+launchctl unload "$HOME/Library/LaunchAgents/com.acsandmann.swipe.plist" 2>/dev/null || true
+(cd "$src" && make install)
+
+echo "aerospace-swipe をインストールしました。"
+echo "初回は System Settings > Privacy & Security > Accessibility で AerospaceSwipe を有効化してください。"

--- a/home/run_onchange_after_macos-defaults.sh
+++ b/home/run_onchange_after_macos-defaults.sh
@@ -38,9 +38,6 @@ defaults write com.apple.dock show-recents -bool false # hide recent apps sectio
 ###############################################################################
 # Mission Control / Displays
 ###############################################################################
-# Dock/menu bar を主ディスプレイのみに表示するため "Displays have separate Spaces" を無効化。
-# AeroSpace のマルチモニタ運用で外部ディスプレイ側に Dock が出ないようにする。
-# (反映にはログアウト/再起動が必要)
 defaults write com.apple.spaces spans-displays -bool true
 
 ###############################################################################

--- a/home/run_onchange_after_macos-defaults.sh
+++ b/home/run_onchange_after_macos-defaults.sh
@@ -36,6 +36,14 @@ defaults write com.apple.dock autohide -bool false     # don't auto-hide
 defaults write com.apple.dock show-recents -bool false # hide recent apps section
 
 ###############################################################################
+# Mission Control / Displays
+###############################################################################
+# Dock/menu bar を主ディスプレイのみに表示するため "Displays have separate Spaces" を無効化。
+# AeroSpace のマルチモニタ運用で外部ディスプレイ側に Dock が出ないようにする。
+# (反映にはログアウト/再起動が必要)
+defaults write com.apple.spaces spans-displays -bool true
+
+###############################################################################
 # Screenshots
 ###############################################################################
 mkdir -p "$HOME/Desktop/screenshot"


### PR DESCRIPTION
Closes #22

## Summary

AeroSpace（macOS タイリングウィンドウマネージャー）を chezmoi 管理に統合し、トラックパッド swipe・ウィンドウ自動配置・マルチモニタ運用を一通り揃えました。

## 実装内容 (#22 のチェックリスト全て)

| # | タスク | 対応 |
|---|--------|------|
| 1 | Brewfile への追加 | `tap "nikitabobko/tap"` + `cask "nikitabobko/tap/aerospace"` |
| 2 | README 技術スタックへの記載 | `ウィンドウ管理` 行を追加 |
| 3 | ワークスペース割り当ての更新 | `exec-on-workspace-change` で `float-f.sh` を呼び出し WS F を常時 floating 化、`alt-left/right` で同モニタの非空ワークスペースをサイクル |
| 4 | トラックパッドでのワークスペース移動 | [taiyo2001/aerospace-swipe](https://github.com/taiyo2001/aerospace-swipe) フォークを `run_onchange_after_install-aerospace-swipe.sh` でソースビルド・launchd 常駐登録。感度は `~/.config/aerospace-swipe/config.json` で管理 |
| 5 | Dock を外部ディスプレイに表示しない | `defaults write com.apple.spaces spans-displays -bool true` を `run_onchange_after_macos-defaults.sh` に追加（反映にはログアウト/再起動が必要） |

## 付随変更

- 廃止された `tap "homebrew/bundle"` / `tap "homebrew/services"` を Brewfile から削除（Homebrew に取り込まれ deprecated）
- `aerospace.toml` を `aerospace.toml.tmpl` にリネームし、ヘルパースクリプトのパスを `{{ .chezmoi.homeDir }}` テンプレで解決
- `float-f.sh` / `ws-nav.sh` を `home/dot_config/aerospace/executable_*.sh` として chezmoi 配下に追加（実行権限付き）

## ヘルパースクリプトの役割

- `float-f.sh` — `on-window-detected if.workspace=F` がウィンドウ「検出時」しか発火しない問題への workaround。WS F にフォーカスが移るたびに既存ウィンドウを floating 化し、手動移動も拾う
- `ws-nav.sh` — `alt-left/right` で focus 中モニタの非空ワークスペースを巡回。`workspace --focused` が前モニタを返してしまう挙動への workaround

## 注意事項

- `spans-displays` の変更はログアウト/再起動するまで反映されない
- aerospace-swipe は ad-hoc 署名のため、再ビルド（`chezmoi apply`）のたびに System Settings > Privacy & Security > Accessibility で **AerospaceSwipe** を再付与する必要がある

## Test plan

- [ ] 新規マシンで `chezmoi init taiyo2001 --apply` → `brew bundle --global` が完走する
- [ ] `chezmoi diff` で `aerospace.toml.tmpl` のテンプレ展開が正しい絶対パスに解決される
- [ ] `alt-right` / `alt-left` で同モニタの非空ワークスペースのみを巡回できる
- [ ] WS F に手動でウィンドウを移動した場合に floating 化される
- [ ] `chezmoi apply` 後、aerospace-swipe がビルドされ launchd service が `~/Library/LaunchAgents/com.acsandmann.swipe.plist` に登録される
- [ ] ログアウト後、外部ディスプレイに Dock が表示されなくなる

🤖 Generated with [Claude Code](https://claude.com/claude-code)