### PR TITLE
feat: Terraform + HCP Terraform で GitHub ブランチ保護を IaC 管理

### DIFF
--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -9,6 +9,8 @@ jobs:
   changes:
     name: Detect Changed Files
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       shell: ${{ steps.filter.outputs.shell }}
       dotfiles: ${{ steps.filter.outputs.dotfiles }}

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -31,7 +31,7 @@ jobs:
               - 'home/dot_config/sheldon/**'
               - 'home/dot_config/starship.toml'
             terraform:
-              - 'terraform/**/*.tf'
+              - '**/*.tf'
 
   check-format:
     name: Shell Script Formatting

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -6,8 +6,37 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    name: Detect Changed Files
+    runs-on: ubuntu-latest
+    outputs:
+      shell: ${{ steps.filter.outputs.shell }}
+      dotfiles: ${{ steps.filter.outputs.dotfiles }}
+      zsh: ${{ steps.filter.outputs.zsh }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shell:
+              - '**/*.sh'
+            dotfiles:
+              - 'home/**'
+              - 'tests/**'
+            zsh:
+              - 'home/dot_zshrc'
+              - 'home/dot_zsh/**'
+              - 'home/dot_config/sheldon/**'
+              - 'home/dot_config/starship.toml'
+            terraform:
+              - 'terraform/**/*.tf'
+
   check-format:
     name: Shell Script Formatting
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +49,8 @@ jobs:
 
   shellcheck:
     name: ShellCheck
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +64,8 @@ jobs:
 
   bats-smoke-test:
     name: Bats Smoke Tests
+    needs: changes
+    if: needs.changes.outputs.dotfiles == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,6 +78,8 @@ jobs:
 
   startup-benchmark:
     name: Zsh Startup Benchmark
+    needs: changes
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.zsh == 'true'
     runs-on: macos-latest
     permissions:
       contents: write
@@ -92,7 +127,6 @@ jobs:
           "
 
       - name: Store benchmark result
-        if: github.ref == 'refs/heads/main'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Zsh Startup Time
@@ -105,6 +139,39 @@ jobs:
           alert-threshold: "150%"
           comment-on-alert: true
           fail-on-alert: false
+
+  terraform-fmt:
+    name: Terraform Format
+    needs: changes
+    if: needs.changes.outputs.terraform == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.15.6"
+
+      - name: Terraform Format Check
+        run: terraform -chdir=terraform fmt -check -recursive
+
+  terraform-validate:
+    name: Terraform Validate
+    needs: changes
+    if: needs.changes.outputs.terraform == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.15.6"
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init -backend=false
+
+      - name: Terraform Validate
+        run: terraform -chdir=terraform validate
 
   secret-scanning:
     name: Secret Scanning

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -15,10 +15,9 @@ jobs:
       shell: ${{ steps.filter.outputs.shell }}
       dotfiles: ${{ steps.filter.outputs.dotfiles }}
       zsh: ${{ steps.filter.outputs.zsh }}
+      terraform: ${{ steps.filter.outputs.terraform }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: dorny/paths-filter@v3
         id: filter

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -17,6 +17,8 @@ jobs:
       zsh: ${{ steps.filter.outputs.zsh }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: dorny/paths-filter@v3
         id: filter

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+terraform = "1.15.6"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,15 @@ setup/apply:
 	chezmoi apply
 	lefthook install
 
+tf/init:
+	cd terraform && op run --env-file=.env.tpl -- terraform init
+
+tf/plan:
+	cd terraform && op run --env-file=.env.tpl -- terraform plan
+
+tf/apply:
+	cd terraform && op run --env-file=.env.tpl -- terraform apply
+
 ci/local:
 	lefthook run pre-push
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ make docker/down     # コンテナを停止・削除
 make ci/local
 ```
 
-shfmt・shellcheck・Bats スモークテストを一括実行します。
+shfmt・shellcheck・Bats スモークテスト・Terraform fmt/validate を一括実行します。
 
 ### pre-push フック
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ macOS 向け dotfiles。[chezmoi](https://www.chezmoi.io/) + [1Password CLI](htt
     <tr><td>シェル</td><td>zsh + <a href="https://sheldon.cli.rs/">Sheldon</a> · <a href="https://starship.rs/">Starship</a> · <a href="https://atuin.sh/">atuin</a> · <a href="https://github.com/ajeetdsouza/zoxide">zoxide</a> · <a href="https://github.com/sharkdp/fd">fd</a> + <a href="https://github.com/junegunn/fzf">fzf</a></td></tr>
     <tr><td>開発環境</td><td><a href="https://neovim.io/">Neovim</a> · <a href="https://github.com/tmux/tmux">tmux</a> + <a href="https://github.com/tmux-plugins/tpm">tpm</a> · <a href="https://www.cmux.dev/">cmux</a></td></tr>
     <tr><td>Git</td><td><a href="https://github.com/evilmartians/lefthook">lefthook</a></td></tr>
+    <tr><td>インフラ</td><td><a href="https://www.terraform.io/">Terraform</a> + <a href="https://app.terraform.io/">HCP Terraform</a></td></tr>
   </tbody>
 </table>
 
@@ -47,6 +48,7 @@ macOS 向け dotfiles。[chezmoi](https://www.chezmoi.io/) + [1Password CLI](htt
     <tr><td><code>home/dot_zsh/</code></td><td>zsh モジュール（exports / aliases / functions / completions）</td></tr>
     <tr><td><code>home/dot_config/sheldon/</code></td><td>Sheldon プラグイン設定（<code>plugins.toml</code>）</td></tr>
     <tr><td><code>app/</code></td><td><a href="#アプリ設定のインポート">アプリ設定のインポート</a></td></tr>
+    <tr><td><code>terraform/</code></td><td><a href="#インフラ設定">インフラ設定</a></td></tr>
     <tr><td><code>tests/</code></td><td>Bats スモークテスト</td></tr>
   </tbody>
 </table>
@@ -129,6 +131,10 @@ make -C ~/.local/share/chezmoi setup/apply
 
 [こちら](./app/README.md)を参照
 
+### インフラ設定
+
+[こちら](./terraform/README.md)を参照
+
 ---
 
 ## dotfilesの編集フロー
@@ -181,4 +187,3 @@ shfmt・shellcheck・Bats スモークテストを一括実行します。
 
 `git push` 時に自動で `make ci/local` と同等のチェックが実行されます（lefthook）。
 `make setup/apply` 実行時に `lefthook install` も同時に行われるため、追加の作業は不要です。
-

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,3 +11,13 @@ pre-push:
     smoke-tests:
       name: Bats Smoke Tests
       run: bats tests/
+
+    terraform-fmt:
+      name: Terraform Format
+      glob: "terraform/*.tf"
+      run: terraform -chdir=terraform fmt -recursive
+
+    terraform-validate:
+      name: Terraform Validate
+      glob: "terraform/*.tf"
+      run: terraform -chdir=terraform validate

--- a/terraform/.env.tpl
+++ b/terraform/.env.tpl
@@ -1,0 +1,4 @@
+TF_TOKEN_app_terraform_io=op://Private/dotfiles/TF_TOKEN_app_terraform_io
+TF_VAR_github_app_id=op://Private/dotfiles/GITHUB_APP_ID
+TF_VAR_github_app_installation_id=op://Private/dotfiles/GITHUB_APP_INSTALLATION_ID
+TF_VAR_github_app_pem_file=op://Private/dotfiles/GITHUB_APP_PEM_FILE

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,6 @@
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+crash.log
+.env

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.12.1"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:hHOwf554tYL9pQS2uRPbaAGSXRbbBJ/+HtQAoT9mtuA=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,20 @@
+## インフラ管理
+
+### 前提条件
+
+1Password の `Private/dotfiles` アイテムに以下のフィールドを追加してください：
+
+| フィールド名 | 内容 |
+|---|---|
+| `TF_TOKEN_app_terraform_io` | HCP Terraform API トークン（無期限） |
+| `GITHUB_APP_ID` | GitHub App ID |
+| `GITHUB_APP_INSTALLATION_ID` | GitHub App Installation ID |
+| `GITHUB_APP_PEM_FILE` | GitHub App 秘密鍵（PEM 形式） |
+
+### 操作
+
+```sh
+make tf/init   # 初回のみ
+make tf/plan   # 差分確認
+make tf/apply  # 適用
+```

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -1,0 +1,30 @@
+provider "github" {
+  owner = "taiyo2001"
+  app_auth {
+    id              = var.github_app_id
+    installation_id = var.github_app_installation_id
+    pem_file        = var.github_app_pem_file
+  }
+}
+
+data "github_repository" "dotfiles" {
+  name = "dotfiles"
+}
+
+resource "github_branch_protection" "main" {
+  repository_id = data.github_repository.dotfiles.node_id
+  pattern       = "main"
+
+  allows_force_pushes = false
+  allows_deletions    = false
+  lock_branch         = true
+  enforce_admins      = false
+}
+
+resource "github_branch_protection" "gh_pages" {
+  repository_id = data.github_repository.dotfiles.node_id
+  pattern       = "gh-pages"
+
+  allows_force_pushes = false
+  allows_deletions    = false
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,14 @@
+variable "github_app_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "github_app_installation_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "github_app_pem_file" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = "~> 1.15"
+
+  cloud {
+    organization = "taiyo2001"
+    workspaces {
+      name = "dotfiles"
+    }
+  }
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
closes #23

## Summary

- `terraform-provider-github` で `main` / `gh-pages` ブランチの保護ルールをコード管理
- State を HCP Terraform（無料枠・500リソースまで）に保存
- シークレットは既存の 1Password CLI（`op run --env-file`）で注入
- GitHub App でリポジトリ単位の最小権限（Administration: Read & Write）で認証
- `mise` で Terraform バージョン（1.15.6）をプロジェクトレベルで固定

## 変更内容

### Terraform
- `terraform/` — Terraform 設定（versions / github / variables）
- `terraform/.env.tpl` — `op run` 用シークレットテンプレート（`op://Private/dotfiles/` に統一）
- `.mise.toml` — Terraform 1.15.6 バージョン固定

### CI / Lint
- `lefthook.yml` — `terraform fmt`（自動整形）・`terraform validate` を pre-push に追加
- `.github/workflows/push_ci.yml` — 以下を追加・修正
  - `terraform-fmt`（チェックのみ）・`terraform-validate` ジョブを追加
  - `dorny/paths-filter` で全ジョブにパスフィルタを設定（関連ファイル変更時のみ実行）
  - `changes` ジョブに `permissions: pull-requests: read` を追加（GitHub API 経由で PR 差分取得）

### その他
- `Makefile` — `tf/init` / `tf/plan` / `tf/apply` ターゲット追加
- `README.md` / `terraform/README.md` — セットアップ手順追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)